### PR TITLE
Avoid uninitialized value warning when comparing IPv6 and IPv4 address

### DIFF
--- a/lib/Plack/Middleware/Access.pm
+++ b/lib/Plack/Middleware/Access.pm
@@ -65,6 +65,9 @@ sub prepare_app {
                 my $addr = $_[0]->{REMOTE_ADDR};
                 my $ip;
                 if (defined($addr) && ($ip = Net::IP->new($addr))) {
+                    if ($netip->version() != $ip->version()) {
+                        return undef; # skip rule
+                    }
                     my $overlaps = $netip->overlaps($ip);
                     return $overlaps == $IP_B_IN_A_OVERLAP || $overlaps == $IP_IDENTICAL;
                 } else {
@@ -114,6 +117,8 @@ sub call {
         allow => "192.168.1.5",
         deny  => "192.168.1/24",
         allow => "192.0.0.10",
+        deny  => "2001:db8:1:2::/64",
+        allow => "2001:db8::/32",
         deny  => "all"
     ];
     $app;

--- a/t/10_main.t
+++ b/t/10_main.t
@@ -46,11 +46,31 @@ my @tests = (
                 allow => sub { shift()->{REMOTE_ADDR} =~ /7/ }, # this rule should work
                 deny  => 'all' ],
      status => 200
+    },
+    {
+     rules => [ deny => '127.0.0.1', allow => '::1', deny => 'all' ],
+     status => 200,
+     remote_addr => '::1',
+    },
+    {
+     rules => [ allow => '127.0.0.1', deny => '::1', allow => 'all' ],
+     status => 403,
+     remote_addr => '::1',
+    },
+    {
+     rules => [ deny => "2001:db8:1:2::/64", allow => "2001:db8::/32", deny => "all" ],
+     status => 403,
+     remote_addr => '2001:db8:1:2::1',
+    },
+    {
+     rules => [ deny => "2001:db8:1:2::/64", allow => "2001:db8::/32", deny => "all" ],
+     status => 200,
+     remote_addr => '2001:db8::1',
     }
 );
 
 foreach my $test (@tests) {
-    my $app = get_handler($test->{rules}, $test->{deny_page});
+    my $app = get_handler($test->{rules}, $test->{deny_page}, $test->{remote_addr});
 
     test_psgi app => $app, client => sub {
         my $cb = shift;
@@ -64,11 +84,18 @@ foreach my $test (@tests) {
 done_testing;
 
 sub get_handler {
-    my ($rules, $deny_page) = @_;
-    my $app = builder {
+    my ($rules, $deny_page, $remote_addr) = @_;
+    my $base_app = builder {
         enable "Plack::Middleware::Access", rules => $rules, deny_page => $deny_page;
         sub {
             return [ 200, [ 'Content-Type' => 'plain/text' ], ['hello there']];
         };
+    };
+    my $app = sub {
+        my $env = shift;
+        if (defined($remote_addr)) {
+            $env->{REMOTE_ADDR} = $remote_addr;
+        }
+        $base_app->($env);
     };
 }


### PR DESCRIPTION
When I tried to use this middleware in a setup where IPv6 is in use, I noticed that uninitialized value warnings are emitted when it executes. It seems that `Net::IP->overlaps(...)` returns `undef` when the compared IP addresses have different versions, i.e. IPv4 vs. IPv6, which results in uninitialized value warnings when determining the return value. With the changes in this pull request, the rule is simply skipped if the IP address versions don't match.